### PR TITLE
Gulp enabled and git commit hooked.

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -1,0 +1,27 @@
+'use strict';
+
+var gulp = require('gulp'),
+    guppy = require('git-guppy')(gulp),
+    jshint = require('gulp-jshint'),
+    jscs = require('gulp-jscs'),
+    jsSources = ['*.js', 'lib/*.js'];
+
+gulp.task('default', ['lint', 'style'], function () {
+});
+
+gulp.task('pre-commit', ['lint', 'style'], function () {
+});
+
+gulp.task('lint', function() {
+    return gulp.src(jsSources)
+        .pipe(jshint())
+        .pipe(jshint.reporter('default'))
+        .pipe(jshint.reporter('fail'));
+});
+
+gulp.task('style', function() {
+    return gulp.src(jsSources)
+        .pipe(jscs())
+        .pipe(jscs.reporter())
+        .pipe(jscs.reporter('fail'));
+});

--- a/package.json
+++ b/package.json
@@ -27,6 +27,12 @@
   },
   "devDependencies": {
     "chai": "^3.5.0",
+    "git-guppy": "^1.2.1",
+    "gulp": "^3.9.1",
+    "gulp-jscs": "^4.0.0",
+    "gulp-jshint": "^2.0.1",
+    "guppy-pre-commit": "^0.3.0",
+    "jshint": "^2.9.2",
     "mocha": "^2.5.3"
   }
 }


### PR DESCRIPTION
Adds gulp for tooling support. Using guppy for git hooks, now runs lint and style tasks before commit is allowed.