### PR TITLE
Fix for https://github.com/Nordstrom/artillery-plugin-aws-sigv4/issues/13

### DIFF
--- a/lib/aws-sigv4.js
+++ b/lib/aws-sigv4.js
@@ -3,6 +3,9 @@
 var aws = require('aws-sdk'),
     L = require('lodash'),
     url = require('url'),
+    traverse = require('traverse'),
+    esprima = require('esprima'),
+
     constants = {
         PLUGIN_PREFIX: 'artillery-plugin-',
         PLUGIN_NAME: 'aws-sigv4',
@@ -67,32 +70,32 @@ var aws = require('aws-sdk'),
             }
             return result;
         },
-
         renderVariables: function(str, vars) {
-            const RX = /{{{?[\s$\w\.\[\]\'\"]+}}}?/g;
-            let rxmatch;
-            let result = str.substring(0, str.length);
-
+            var RX = /{{{?[\s$\w\.\[\]\'\"]+}}}?/g,
+                rxmatch,
+                varName,
+                templateStr,
+                varValue,
+                result = str.substring(0, str.length),
+                matches = str.match(RX);
 
             // Special case for handling integer/boolean/object substitution:
             //
             // Does the template string contain one variable and nothing else?
             // e.g.: "{{ myvar }" or "{{    myvar }", but NOT " {{ myvar }"
             // If so, we treat it as a special case.
-            const matches = str.match(RX);
             if (matches && matches.length === 1) {
                 if (matches[0] === str) {
                     // there's nothing else in the template but the variable
-                    const varName = str.replace(/{/g, '').replace(/}/g, '').trim();
+                    varName = str.replace(/{/g, '').replace(/}/g, '').trim();
                     return L.get(vars, varName) || '';
                 }
             }
 
             while (result.search(RX) > -1) {
-                let templateStr = result.match(RX)[0];
-                const varName = templateStr.replace(/{/g, '').replace(/}/g, '').trim();
-
-                let varValue = L.get(vars, varName);
+                templateStr = result.match(RX)[0];
+                varName = templateStr.replace(/{/g, '').replace(/}/g, '').trim();
+                varValue = L.get(vars, varName);
 
                 if (typeof varValue === 'object') {
                     varValue = JSON.stringify(varValue);
@@ -104,7 +107,7 @@ var aws = require('aws-sdk'),
         },
 
         template: function (o, context) {
-            let result;
+            var result, funcCallRegex, funcName, args, syntax, match;
 
             if (typeof o === 'undefined') {
                 return undefined;
@@ -112,9 +115,8 @@ var aws = require('aws-sdk'),
 
             if (o.constructor === Object) {
                 result = traverse(o).map(function (x) {
-
                     if (typeof x === 'string') {
-                        this.update(template(x, context));
+                        this.update(this.template(x, context));
                     } else {
                         return x;
                     }
@@ -123,20 +125,22 @@ var aws = require('aws-sdk'),
                 if (!/{{/.test(o)) {
                     return o;
                 }
-                const funcCallRegex = /{{\s*(\$[A-Za-z0-9_]+\s*\(\s*.*\s*\))\s*}}/;
-                let match = o.match(funcCallRegex);
+
+                funcCallRegex = /{{\s*(\$[A-Za-z0-9_]+\s*\(\s*.*\s*\))\s*}}/;
+                match = o.match(funcCallRegex);
+
                 if (match) {
                     // This looks like it could be a function call:
-                    const syntax = esprima.parse(match[1]);
+                    syntax = esprima.parse(match[1]);
                     // TODO: Use a proper schema for what we expect here
                     if (syntax.body && syntax.body.length === 1 &&
                         syntax.body[0].type === 'ExpressionStatement') {
-                        let funcName = syntax.body[0].expression.callee.name;
-                        let args = L.map(syntax.body[0].expression.arguments, function (arg) {
+                        funcName = syntax.body[0].expression.callee.name;
+                        args = L.map(syntax.body[0].expression.arguments, function (arg) {
                             return arg.value;
                         });
                         if (funcName in context.funcs) {
-                            return template(o.replace(funcCallRegex, context.funcs[funcName].apply(null, args)), context);
+                            return this.template(o.replace(funcCallRegex, context.funcs[funcName].apply(null, args)), context);
                         }
                     }
                 } else {
@@ -221,7 +225,7 @@ var aws = require('aws-sdk'),
                                 sdkCredentialsError.message
                             ].join(''));
                         } else {
-                            p = {requestParams: requestParams, context: context, ee: ee, callback: callback};
+                            p = { requestParams: requestParams, context: context, ee: ee, callback: callback };
                         }
                     } else {
                         impl.addAmazonSignatureV4(serviceName, requestParams, context, ee, callback);

--- a/lib/aws-sigv4.js
+++ b/lib/aws-sigv4.js
@@ -1,6 +1,7 @@
 'use strict';
 
 var aws = require('aws-sdk'),
+    L = require('lodash'),
     url = require('url'),
     constants = {
         PLUGIN_PREFIX: 'artillery-plugin-',
@@ -66,7 +67,93 @@ var aws = require('aws-sdk'),
             }
             return result;
         },
-        addAmazonSignatureV4: function(serviceName, requestParams, context, ee, callback) {
+
+        renderVariables: function(str, vars) {
+            const RX = /{{{?[\s$\w\.\[\]\'\"]+}}}?/g;
+            let rxmatch;
+            let result = str.substring(0, str.length);
+
+
+            // Special case for handling integer/boolean/object substitution:
+            //
+            // Does the template string contain one variable and nothing else?
+            // e.g.: "{{ myvar }" or "{{    myvar }", but NOT " {{ myvar }"
+            // If so, we treat it as a special case.
+            const matches = str.match(RX);
+            if (matches && matches.length === 1) {
+                if (matches[0] === str) {
+                    // there's nothing else in the template but the variable
+                    const varName = str.replace(/{/g, '').replace(/}/g, '').trim();
+                    return L.get(vars, varName) || '';
+                }
+            }
+
+            while (result.search(RX) > -1) {
+                let templateStr = result.match(RX)[0];
+                const varName = templateStr.replace(/{/g, '').replace(/}/g, '').trim();
+
+                let varValue = L.get(vars, varName);
+
+                if (typeof varValue === 'object') {
+                    varValue = JSON.stringify(varValue);
+                }
+                result = result.replace(templateStr, varValue);
+            }
+
+            return result;
+        },
+
+        template: function (o, context) {
+            let result;
+
+            if (typeof o === 'undefined') {
+                return undefined;
+            }
+
+            if (o.constructor === Object) {
+                result = traverse(o).map(function (x) {
+
+                    if (typeof x === 'string') {
+                        this.update(template(x, context));
+                    } else {
+                        return x;
+                    }
+                });
+            } else if (typeof o === 'string') {
+                if (!/{{/.test(o)) {
+                    return o;
+                }
+                const funcCallRegex = /{{\s*(\$[A-Za-z0-9_]+\s*\(\s*.*\s*\))\s*}}/;
+                let match = o.match(funcCallRegex);
+                if (match) {
+                    // This looks like it could be a function call:
+                    const syntax = esprima.parse(match[1]);
+                    // TODO: Use a proper schema for what we expect here
+                    if (syntax.body && syntax.body.length === 1 &&
+                        syntax.body[0].type === 'ExpressionStatement') {
+                        let funcName = syntax.body[0].expression.callee.name;
+                        let args = L.map(syntax.body[0].expression.arguments, function (arg) {
+                            return arg.value;
+                        });
+                        if (funcName in context.funcs) {
+                            return template(o.replace(funcCallRegex, context.funcs[funcName].apply(null, args)), context);
+                        }
+                    }
+                } else {
+                    if (!o.match(/{{/)) {
+                        return o;
+                    }
+
+                    result = this.renderVariables(o, context.vars);
+                }
+            } else {
+                return o;
+            }
+
+            return result;
+        },
+
+        addAmazonSignatureV4: function (serviceName, requestParams, context, ee, callback) {
             var targetUrl = url.parse(requestParams.uri || requestParams.url),
                 credentials = aws.config.credentials,
                 region = aws.config.region,
@@ -86,9 +173,9 @@ var aws = require('aws-sdk'),
                 }
 
                 if (requestParams.body) {
-                    req.body = requestParams.body;
+                    req.body = this.template(requestParams.body, context);
                 } else if (requestParams.json) {
-                    req.body = JSON.stringify(requestParams.json);
+                    req.body = this.template(JSON.stringify(requestParams.json), context);
                 }
 
                 signer = new aws.Signers.V4(req, serviceName);
@@ -134,7 +221,7 @@ var aws = require('aws-sdk'),
                                 sdkCredentialsError.message
                             ].join(''));
                         } else {
-                            p = { requestParams: requestParams, context: context, ee: ee, callback: callback };
+                            p = {requestParams: requestParams, context: context, ee: ee, callback: callback};
                         }
                     } else {
                         impl.addAmazonSignatureV4(serviceName, requestParams, context, ee, callback);
@@ -153,3 +240,4 @@ module.exports.messages = messages;
 module.exports.impl = impl;
 module.exports.api = api;
 /* end-test-code */
+


### PR DESCRIPTION
Due to changes in artillery in the linked issue above, templating needs to be run prior to the calculation of the AWS V4 signature. The current newest stable branch of artillery triggers beforeRequest prior to template / variable substitution.

Took the changes from the artillery core (engine_util) and moved over the relevant functions to make it work. Ran through tests again execute-api and confirmed that the generated signatures are correct.