### PR TITLE
Fix signing for paths with variables in them

### DIFF
--- a/lib/aws-sigv4.js
+++ b/lib/aws-sigv4.js
@@ -77,7 +77,8 @@ var aws = require('aws-sdk'),
 
             if (impl.validateSdkConfig(credentials, region)) {
                 req.method = requestParams.method;
-                req.path = targetUrl.path;
+                req.path = impl.substitutePathVariables(targetUrl.path, context.vars)
+
                 req.region = region;
                 req.headers.Host = end.host;
 
@@ -99,6 +100,14 @@ var aws = require('aws-sdk'),
                 }
             }
             callback();
+        },
+        substitutePathVariables: function(path, vars) {
+            Object.getOwnPropertyNames(vars).forEach((key) => {
+                path = path.replace(`%7B%7B%20${key}%20%7D%7D`, vars[key]);
+                path = path.replace(`%7B%7B${key}%7D%7D`, vars[key]);
+            })
+
+            return path
         }
     },
     api = {


### PR DESCRIPTION
Signature was calculated from pre-interpolation paths, e.g.,
`foo.com/bar/{{id}}`. Now, path is interpolated before signing, e.g.,
`foo.com/bar/1`. This should be safe for interpolation in the form
`{{variable}}` or `{{ variable }}`.