### PR TITLE
- the plugin gets the region from the aws.config and thus the region …

### DIFF
--- a/lib/aws-sigv4.js
+++ b/lib/aws-sigv4.js
@@ -4,6 +4,7 @@ const aws = require('aws-sdk')
 const URL = require('url').URL
 
 const PLUGIN_NAME = 'aws-sigv4'
+const AWS_REGION = "region"
 
 const messages = {
   pluginConfigRequired: `The ${PLUGIN_NAME} plugin requires configuration under [script].config.plugins.${PLUGIN_NAME}.`,
@@ -114,8 +115,10 @@ const impl = {
 // Implement plugin to be consumed by Artillery.
 const AwsSigV4Plugin = function (scriptConfig, eventEmitter) {
   // Collect configuration from the environment and validate.
+
+  const inputConfigAWSRegion = scriptConfig.plugins[PLUGIN_NAME][AWS_REGION]
   const credentials = aws.config.credentials
-  const region = aws.config.region
+  const region = (inputConfigAWSRegion === undefined || inputConfigAWSRegion === '') ? aws.config.region : inputConfigAWSRegion
   const sdkConfigurationIsValid = impl.validateSdkConfig(credentials, region)
 
   if (!sdkConfigurationIsValid) {


### PR DESCRIPTION
#Motivation

- the plugin gets the region from the aws.config and thus the region is always the aws region in which the artillery stack is deployed. Thus the request is always signed with the region in which the artillery stack is deployed and this makes, making a cross region call to the service that needs to be load tested impossible.

#Desciption

- adding an option in the plugin section of the script.yml to provide the region with which the request signing should be done. If no region parameter is provided then the region will default to aws.config.region.