### PR TITLE
merge requests dicts

### DIFF
--- a/lib/aws-sigv4.js
+++ b/lib/aws-sigv4.js
@@ -102,9 +102,7 @@ const impl = {
 
     // Copy the headers from the AWS HttpRequest back to the Artillery requestParams.
     //  This will now include the necessary Authorization header needed for AWS.
-    for (header in request.headers) {
-      requestParams.headers[header] = request.headers[header]
-    }
+    requestParams.headers = Object.assign({}, requestParams.headers,  req.headers);
 
     // Allow Artillery to continue.
     callback()


### PR DESCRIPTION

If we do not define headers in the config.yaml the plugin throws:
 `errors.Cannot set properties of undefined (setting 'User-Agent'):`
 
This is becouse r`equestParams.headers[header]` is undefined in this case.
